### PR TITLE
Upload Kover report only from the root project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,7 @@ jobs:
       - checkout
       - run: ./gradlew check
       - run: ./gradlew koverXmlReport
-      - codecov/upload:
-          file: build/reports/kover/report.xml
+      - codecov/upload
 
 workflows:
   test:

--- a/internal/test/build.gradle.kts
+++ b/internal/test/build.gradle.kts
@@ -6,3 +6,7 @@ dependencies {
     implementation(libs.kotlinx.coroutines.test)
     implementation(libs.junit4)
 }
+
+kover {
+    disable()
+}


### PR DESCRIPTION
The [final stage of CI](https://app.circleci.com/pipelines/github/Antimonit/EventBuffer/9/workflows/f09c460f-d7d7-4381-8af5-6c893e1e0af9/jobs/9/parallel-runs/0/steps/0-106) reports:
> info - 2024-03-16 14:32:44,404 -- Found 4 coverage files to upload
> info - 2024-03-16 14:32:44,405 -- > /home/circleci/repo/event-buffer/internal/test/build/reports/kover/report.xml
> info - 2024-03-16 14:32:44,405 -- > /home/circleci/repo/event-buffer/build/reports/kover/report.xml
> info - 2024-03-16 14:32:44,405 -- > /home/circleci/repo/event-buffer/event-buffer-test/build/reports/kover/report.xml
> info - 2024-03-16 14:32:44,405 -- > /home/circleci/repo/event-buffer/event-buffer-core/build/reports/kover/report.xml

We don't want the `:internal:test` module to be tracked.

The root `:` project already combines the reports for modules we are interested in. Try to upload only that one.