### PR TITLE
Update codecov to 6.0.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codecov: codecov/codecov@6.0.0
+  codecov: codecov/codecov@5.4.3
 
 jobs:
   build:


### PR DESCRIPTION
The 6.0.0 causes issues with PGP keys.